### PR TITLE
Added scripts to run in Google Colab

### DIFF
--- a/Code-Text/code-to-text/README.md
+++ b/Code-Text/code-to-text/README.md
@@ -39,6 +39,34 @@ rm -r */final
 cd ..
 ```
 
+### Download data and preprocess in an online notebook(like Google Colab)
+
+```shell
+import os
+!unzip dataset.zip
+os.chdir("/content/dataset")
+!wget https://s3.amazonaws.com/code-search-net/CodeSearchNet/v2/python.zip
+!wget https://s3.amazonaws.com/code-search-net/CodeSearchNet/v2/java.zip
+!wget https://s3.amazonaws.com/code-search-net/CodeSearchNet/v2/ruby.zip
+!wget https://s3.amazonaws.com/code-search-net/CodeSearchNet/v2/javascript.zip
+!wget https://s3.amazonaws.com/code-search-net/CodeSearchNet/v2/go.zip
+!wget https://s3.amazonaws.com/code-search-net/CodeSearchNet/v2/php.zip
+
+!unzip python.zip
+!unzip java.zip
+!unzip ruby.zip
+!unzip javascript.zip
+!unzip go.zip
+!unzip php.zip
+!rm *.zip
+!rm *.pkl
+
+!python preprocess.py
+!rm -r */final
+os.chdir("../")
+```
+
+
 ### Data Format
 
 After preprocessing dataset, you can obtain three .jsonl files, i.e. train.jsonl, valid.jsonl, test.jsonl


### PR DESCRIPTION
Changing of directory in online notebooks is preferred using python's change directory (chdir)  module. Added the scripts for it.