### PR TITLE
fix: Solving the problems of using Bert and DistilBert for classifica…

### DIFF
--- a/Code-Code/Defect-detection/code/run.py
+++ b/Code-Code/Defect-detection/code/run.py
@@ -45,20 +45,20 @@ import multiprocessing
 from model import Model
 cpu_cont = multiprocessing.cpu_count()
 from transformers import (WEIGHTS_NAME, AdamW, get_linear_schedule_with_warmup,
-                          BertConfig, BertForMaskedLM, BertTokenizer,
+                          BertConfig, BertForMaskedLM, BertTokenizer, BertForSequenceClassification,
                           GPT2Config, GPT2LMHeadModel, GPT2Tokenizer,
                           OpenAIGPTConfig, OpenAIGPTLMHeadModel, OpenAIGPTTokenizer,
                           RobertaConfig, RobertaForSequenceClassification, RobertaTokenizer,
-                          DistilBertConfig, DistilBertForMaskedLM, DistilBertTokenizer)
+                          DistilBertConfig, DistilBertForMaskedLM, DistilBertForSequenceClassification, DistilBertTokenizer)
 
 logger = logging.getLogger(__name__)
 
 MODEL_CLASSES = {
     'gpt2': (GPT2Config, GPT2LMHeadModel, GPT2Tokenizer),
     'openai-gpt': (OpenAIGPTConfig, OpenAIGPTLMHeadModel, OpenAIGPTTokenizer),
-    'bert': (BertConfig, BertForMaskedLM, BertTokenizer),
+    'bert': (BertConfig, BertForSequenceClassification, BertTokenizer),
     'roberta': (RobertaConfig, RobertaForSequenceClassification, RobertaTokenizer),
-    'distilbert': (DistilBertConfig, DistilBertForMaskedLM, DistilBertTokenizer)
+    'distilbert': (DistilBertConfig, DistilBertForSequenceClassification, DistilBertTokenizer)
 }
 
 


### PR DESCRIPTION
…tion tasks on the given datasets.

If we don't change run.py and instead directly change the --model_type from RoBERTa to BERT or DistilBERT, there will be dimension errors in the classification tasks.

After addressing the dimension errors, the code seems to run smoothly. However, the evaluation process is interrupted when computing the eval_loss and eval_acc.

It was later discovered that we mistakenly used the wrong model for Bert and DistilBert. BertForMaskedLM is intended for language modeling tasks, while BertForSequenceClassification is designed for text classification. To classify input sentences, we should use BertForSequenceClassification and  DistilBertForSequenceClassification.

log: Solving the problems of using Bert and DistilBert for classification tasks on the given datasets.