### PR TITLE
Enhancing Model Training with Early Stopping and Dropout Layer

### DIFF
--- a/Code-Code/Defect-detection/code/model.py
+++ b/Code-Code/Defect-detection/code/model.py
@@ -17,9 +17,16 @@ class Model(nn.Module):
         self.tokenizer=tokenizer
         self.args=args
     
+        # Define dropout layer, dropout_probability is taken from args.
+        self.dropout = nn.Dropout(args.dropout_probability)
+
         
     def forward(self, input_ids=None,labels=None): 
         outputs=self.encoder(input_ids,attention_mask=input_ids.ne(1))[0]
+
+        # Apply dropout
+        outputs = self.dropout(outputs)
+
         logits=outputs
         prob=torch.sigmoid(logits)
         if labels is not None:

--- a/Code-Code/Defect-detection/code/run.py
+++ b/Code-Code/Defect-detection/code/run.py
@@ -259,14 +259,15 @@ def train(args, train_dataset, model, tokenizer):
         avg_loss = train_loss / tr_num
 
         # Check for early stopping condition
-        if best_loss is None or avg_loss < best_loss - args.min_delta:
-            best_loss = avg_loss
-            early_stopping_counter = 0
-        else:
-            early_stopping_counter += 1
-            if early_stopping_counter >= args.early_stopping_patience:
-                logger.info("Early stopping")
-                break  # Exit the loop early
+        if args.early_stopping_patience is not None:
+            if best_loss is None or avg_loss < best_loss - args.min_loss_delta:
+                best_loss = avg_loss
+                early_stopping_counter = 0
+            else:
+                early_stopping_counter += 1
+                if early_stopping_counter >= args.early_stopping_patience:
+                    logger.info("Early stopping")
+                    break  # Exit the loop early
                         
 
 
@@ -459,11 +460,11 @@ def main():
     parser.add_argument('--server_port', type=str, default='', help="For distant debugging.")
 
     # Add early stopping parameters and dropout probability parameters
-    parser.add_argument("--early_stopping_patience", default=3, type=int,
+    parser.add_argument("--early_stopping_patience", type=int, default=None,
                         help="Number of epochs with no improvement after which training will be stopped.")
-    parser.add_argument("--min_delta", default=0.001, type=float,
-                        help="Minimum change in the monitored quantity to qualify as an improvement.")
-    parser.add_argument('--dropout_probability', type=float, default=0.1, help='dropout probability')
+    parser.add_argument("--min_loss_delta", type=float, default=0.001,
+                        help="Minimum change in the loss required to qualify as an improvement.")
+    parser.add_argument('--dropout_probability', type=float, default=0, help='dropout probability')
 
 
     


### PR DESCRIPTION
This pull request introduces a series of updates aimed at optimizing the model training process, incorporating advanced techniques such as dropout layers and early stopping based on loss improvement. Default parameter values have also been revised for enhanced functionality.

Key Improvements and Changes Include:

1. **Dropout Layer Implementation**: A dropout layer has been incorporated into the model. This feature helps to prevent overfitting by randomly setting a fraction of input units to 0 at each update during training, thus improving the model's ability to generalize. The `dropout_probability` parameter has been added to the parser to allow customization of the dropout rate. By default, this parameter is set to 0, effectively disabling the dropout layer.

2. **Early Stopping Based on Loss Improvement**: An early stopping mechanism has been implemented to halt the training process when there's no significant improvement in loss after a certain number of epochs. This feature helps to conserve computational resources and avoid overfitting. Two parameters have been added to facilitate this feature:

    - `early_stopping_patience`: This determines the number of epochs with no loss improvement after which training will be stopped. It is disabled by default with a value of None.
    - `min_loss_delta`: This parameter specifies the minimum change in loss that qualifies as an improvement. It is set to a default value of 0.001.

These enhancements aim to provide users with greater control over the training process while promoting the development of more robust and efficient models.